### PR TITLE
[Switch] Fix API URI

### DIFF
--- a/fbx_monitor.py
+++ b/fbx_monitor.py
@@ -251,7 +251,7 @@ class MonitoringAgent:
         Get Switch status
         :return:
         """
-        return self.api.get("switch/status")
+        return self.api.get("switch/status/")
 
     def freeplugs(self):
         """


### PR DESCRIPTION
Hello,

I just install the script and notice the switch command gives me an error. Debugging it with the `-d` option, I got a 404 on the `switch/status` URI (I'm using a Freebox mini 4k).

According to the [doc](https://dev.freebox.fr/sdk/os/switch/), it seems the trailing slash of the URI makes the difference.